### PR TITLE
Add go.mod, fix import path for github.com/bouk/monkey

### DIFF
--- a/blocker_test.go
+++ b/blocker_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"aahframework.org/test.v0/assert"
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 )
 
 func Test_it_block_as_expected(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/ghetzel/ratelimit
+
+go 1.13
+
+require (
+	aahframework.org/test.v0 v0.0.0-20170303192812-d14ae1dc852d
+	bou.ke/monkey v1.0.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+aahframework.org/test.v0 v0.0.0-20170303192812-d14ae1dc852d h1:xrk269ZdyicxrmDDwLkjpWxzBeApYPKmGlAXtXylB0k=
+aahframework.org/test.v0 v0.0.0-20170303192812-d14ae1dc852d/go.mod h1:Dc0WOMD7SnuzGgAI29bLYayM5XoDr+Iha/jfObqPwhA=
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"aahframework.org/test.v0/assert"
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 )
 
 func Test_IT_PANIC_WHEN_INVALID_NEW_RATE_PATTERN(t *testing.T) {

--- a/spammer_test.go
+++ b/spammer_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"aahframework.org/test.v0/assert"
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
 )
 
 func Test_it_count_spam_as_expected(t *testing.T) {


### PR DESCRIPTION
Hello!  Recently, it appears that the `github.com/bouk/monkey` dependency has rehomed their module to `bou.ke/monkey`. For upstream modules that use the new(ish) [Go modules](https://github.com/golang/go/wiki/Modules) feature, this import path is now causing build errors:

```
go get ./...
go: github.com/bouk/monkey@v1.0.2: parsing go.mod:
	module declares its path as: bou.ke/monkey
	        but was required as: github.com/bouk/monkey
```

I have made the necessary fixes in my fork, and wanted to PR them back to you if you are interested.

1. Adds a go.mod and go.sum file to the project to track versions of dependencies.
2. Changes all instances of the import path from `github.com/bouk/monkey` to `bouke/monkey`.

Thank you for this package.

Cheers,

Gary